### PR TITLE
Alpine Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
    <a href="https://dwm.suckless.org/">
     <img src="https://img.shields.io/badge/dwm-powered-important?logo=fedora&style=flat-square" alt="Lint CI">
   </a>
+   <a href="https://dwm.suckless.org/">
+    <img src="https://img.shields.io/badge/dwm-powered-important?logo=alpinelinux&style=flat-square" alt="Lint CI">
+  </a>
   <a href="https://github.com/andros21/dotfiles/blob/master/LICENSE">
     <img src="https://img.shields.io/github/license/andros21/dotfiles?color=blue&label=License&style=flat-square" alt="License">
   </a>
@@ -33,8 +36,11 @@
 #### X server `Xorg`
 
 * Nord color style, thanks to [Nord Xresources](https://github.com/arcticicestudio/nord-xresources)
-* Custom Xsession starting **dwm** as WM on Xorg
-* `Xresources/.profile` sourced (by `xinitrc-common` on Fedora) to prepare X env, before WM start
+* On `fedora`:
+   + Custom Xsession starting **dwm** as WM on Xorg
+   + `Xresources/.profile` sourced (by `xinitrc-common`) to prepare X env, before WM start
+* On `alpine`:
+   + Custom `.xinitrc` for starting **dwm** with `startx`
 
 #### Window manager `dwm`
 
@@ -81,8 +87,7 @@ Here my build [slock](https://github.com/andros21/slock)
 
 #### Launcher `rofi`
 
-* Xresources color/style setup
-* Custom default theme `my-default.rasi`
+* Custom theme `nord.rasi`
 
 #### Editor `neovim`
 
@@ -122,8 +127,14 @@ Here my build [slock](https://github.com/andros21/slock)
 ### Prerequisites
 
 * `fedora >= 34`
-* `requirements.txt`
-* `requirements-dev.txt` (optional, for devel)
+   + a sudo user
+   + `requirements.txt`
+   + `requirements-dev.txt` (devel)
+* `alpine >= 3.15`
+   + a sudo user
+   + maybe `apk add py3-pip py3-cffi`
+   + `requirements.txt`
+   + `requirements-dev.txt` (devel)
 
 ### How to run
 

--- a/Xresources/.Xresources
+++ b/Xresources/.Xresources
@@ -1,14 +1,12 @@
-! =========================
+! ========================
 ! Xresources Configuration
-! =========================
+! ========================
 !
 ! Features:
 !  * nord theme color (+ ARGB color)
 !  * dwm  style
-!  * rofi style
 !
 ! Author: Andrea Rossoni
-! Date:   2021.10.17
 !
 
 ! Color Config
@@ -16,6 +14,3 @@
 
 ! Dwm Config
 #include ".Xresources.d/dwm"
-
-! Rofi Config
-#include ".Xresources.d/rofi"

--- a/Xresources/.profile
+++ b/Xresources/.profile
@@ -1,7 +1,8 @@
-
+# fedora
+# ======
 # Sourced by xinitrc-common
 # setting up my X env, before WM start
-#
+# ------------------------------------
 
 if [ "$GDMSESSION" = "dwm-xorg" ]; then
    # Setup minor screen resolution for built-in screen

--- a/Xresources/.xinitrc
+++ b/Xresources/.xinitrc
@@ -1,0 +1,26 @@
+# alpine
+# ======
+# Sourced by startx
+# setting up my X env and start WM
+# --------------------------------
+
+# Setup minor screen resolution for built-in screen
+xrandr --output eDP-1 --mode 1368x768
+# Setup higher keyboard rate
+xset r rate 300 35
+# Setup keyboard language
+setxkbmap it
+# Xinput set touchpad properties
+xinput set-prop "AlpsPS/2 ALPS GlidePoint" "libinput Tapping Enabled" 1
+xinput set-prop "AlpsPS/2 ALPS GlidePoint" "libinput Natural Scrolling Enabled" 1
+xinput set-prop "AlpsPS/2 ALPS GlidePoint" "libinput Accel Speed" 0.3
+# Setup a static wallpaper
+feh --bg-scale ~/Pictures/Wallpapers/nord.jpg
+# Run in background a window composer (to render alpha effects)
+picom -b
+# Source Xresources
+xrdb -merge ~/.Xresources
+# Run pipewire
+pipewire &> /dev/null &
+# Run WM via dbus
+dbus-launch --exit-with-session dwm

--- a/alacritty/.config/alacritty/alacritty.yml
+++ b/alacritty/.config/alacritty/alacritty.yml
@@ -15,7 +15,7 @@ window:
 
 font:
   normal:
-    family: Hack
+    family: DejaVu Sans Mono
   size: 14
 
 background_opacity: 0.91

--- a/ansible/.ansible/dwm/dwm.yml
+++ b/ansible/.ansible/dwm/dwm.yml
@@ -1,6 +1,10 @@
 ---
 
-- hosts: thinkpad
+- hosts: laptop
+  vars_prompt:
+    - name: become_passwd
+      prompt: BECOME password (expect)
+      private: yes
   roles:
     - role: repo
       tags: repo

--- a/ansible/.ansible/dwm/hosts
+++ b/ansible/.ansible/dwm/hosts
@@ -1,1 +1,1 @@
-thinkpad ansible_connection=local
+laptop ansible_connection=local

--- a/ansible/.ansible/dwm/roles/build/tasks/main.yml
+++ b/ansible/.ansible/dwm/roles/build/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # tasks/main.yml
 
 - name: Build and install forked gits

--- a/ansible/.ansible/dwm/roles/build/vars/main.yml
+++ b/ansible/.ansible/dwm/roles/build/vars/main.yml
@@ -1,3 +1,4 @@
+---
 # vars/main.yml
 
 forked_gits:

--- a/ansible/.ansible/dwm/roles/conf/tasks/alpine.yml
+++ b/ansible/.ansible/dwm/roles/conf/tasks/alpine.yml
@@ -14,26 +14,6 @@
         insertafter: '^#rc_logger(.*)'
         line: rc_logger="YES"
 
-#- name: Setup shell
-  #block:
-    #- name: Touch login.defs
-      #ansible.builtin.file:
-        #path: /etc/login.defs
-        #state: touch
-    #- name: Mkdir default
-      #ansible.builtin.file:
-        #path: /etc/default
-        #state: directory
-    #- name: Touch useradd
-      #ansible.builtin.file:
-        #path: /etc/default/useradd
-        #state: touch
-    #- name: Chsh fish
-      #ansible.builtin.expect:
-        #command: lchsh '{{ ansible_user_id }}'
-        #responses:
-          #(.*): '/usr/bin/fish'
-
 - name: Setup pipewire
   block:
     - name: Load module
@@ -107,6 +87,16 @@
     src: /usr/bin/python3
     dest: /usr/bin/python
     state: link
+
+- name: Add to input group
+  block:
+    - name: Get user
+      ansible.builtin.set_fact:
+        whoami: '{{ ansible_user_id }}'
+      become: no
+    - name: Add to input
+      ansible.builtin.shell:
+        cmd: adduser '{{ whoami }}' input
 
 - name: Chsh fish
   ansible.builtin.expect:

--- a/ansible/.ansible/dwm/roles/conf/tasks/alpine.yml
+++ b/ansible/.ansible/dwm/roles/conf/tasks/alpine.yml
@@ -1,0 +1,117 @@
+---
+# tasks/alpine.yml
+
+- name: Setup openrc
+  block:
+    - name: Parallel yes
+      ansible.builtin.lineinfile:
+        path: /etc/rc.conf
+        insertafter: '^#rc_parallel(.*)'
+        line: rc_parallel="YES"
+    - name: Log yes
+      ansible.builtin.lineinfile:
+        path: /etc/rc.conf
+        insertafter: '^#rc_logger(.*)'
+        line: rc_logger="YES"
+
+#- name: Setup shell
+  #block:
+    #- name: Touch login.defs
+      #ansible.builtin.file:
+        #path: /etc/login.defs
+        #state: touch
+    #- name: Mkdir default
+      #ansible.builtin.file:
+        #path: /etc/default
+        #state: directory
+    #- name: Touch useradd
+      #ansible.builtin.file:
+        #path: /etc/default/useradd
+        #state: touch
+    #- name: Chsh fish
+      #ansible.builtin.expect:
+        #command: lchsh '{{ ansible_user_id }}'
+        #responses:
+          #(.*): '/usr/bin/fish'
+
+- name: Setup pipewire
+  block:
+    - name: Load module
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/snd.conf
+        content: |
+          snd_seq
+    - name: Mkdir pipewire
+      ansible.builtin.file:
+        path: /etc/pipewire
+        state: directory
+    - name: Copy pipewire default
+      ansible.builtin.copy:
+        src: /usr/share/pipewire/pipewire.conf
+        dest: /etc/pipewire/pipewire.conf
+    - name: Enable wireplumber
+      ansible.builtin.lineinfile:
+        path: /etc/pipewire/pipewire.conf
+        insertafter: '(.*)pipewire-pulse.conf(.*)'
+        line: '    { path = "wireplumber"  args = "" }'
+    - name: Enable pulseaudio compatibility
+      ansible.builtin.replace:
+        path: /etc/pipewire/pipewire.conf
+        regexp: '(.*)#(.*pipewire-pulse.conf.*)'
+        replace: '    \2'
+
+- name: Setup network
+  block:
+    - name: Allow eth0 hotplug
+      ansible.builtin.lineinfile:
+        path: /etc/network/interfaces
+        insertafter: '(.*)auto eth0(.*)'
+        line: allow-hotplug eth0
+    - name: Delete auto eth0
+      ansible.builtin.lineinfile:
+        path: /etc/network/interfaces
+        regexp: '(.*)auto eth0(.*)'
+        state: absent
+
+- name: No ipv6
+  ansible.builtin.copy:
+    dest: /etc/sysctl.d/no-ipv6.conf
+    content: |
+      net.ipv6.conf.all.disable_ipv6=1
+
+- name: Setup sensors
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/i2c.conf
+    content: |
+      i2c-dev
+
+- name: Enable services
+  ansible.builtin.shell:
+    cmd: rc-update add '{{ item }}'
+  with_items: '{{ rc_services }}'
+  when: item != 'fwupd'
+
+- name: Enable fwupd
+  block:
+    - name: Check bios or efi
+      ansible.builtin.stat:
+        path: /sys/firmware/efi
+      register: efi
+    - name: Enable fwupd if efi
+      ansible.builtin.shell:
+        cmd: rc-update add fwupd
+      when: efi.stat.exists
+
+- name: Python alias
+  ansible.builtin.file:
+    src: /usr/bin/python3
+    dest: /usr/bin/python
+    state: link
+
+- name: Chsh fish
+  ansible.builtin.expect:
+    command: chsh -s /usr/bin/fish '{{ ansible_user_id }}'
+    timeout:
+    responses:
+      (.*)Password(.*): '{{ become_passwd }}'
+  become: no

--- a/ansible/.ansible/dwm/roles/conf/tasks/common.yml
+++ b/ansible/.ansible/dwm/roles/conf/tasks/common.yml
@@ -1,0 +1,55 @@
+---
+# tasks/common.yml
+
+- name: Setup XDG standard dirs
+  ansible.builtin.shell:
+    cmd: xdg-user-dirs-update
+
+- name: GNU/Stow
+  block:
+    - name: Remove default configs
+      ansible.builtin.file:
+        path: '{{ ansible_user_dir }}/{{ item }}'
+        state: absent
+      with_items: '{{ file_to_rm }}'
+    - name: Create some locations
+      ansible.builtin.file:
+        path: '{{ ansible_user_dir }}/{{ item }}'
+        state: directory
+      with_items: '{{ path_to_mk }}'
+    - name: Collect paths to stow
+      ansible.builtin.find:
+        paths: '{{ ansible_user_dir }}/.dotfiles/'
+        file_type: directory
+        excludes: .cache,.git,.github,Xorg
+      register: find_result
+    - name: Stow them
+      ansible.builtin.shell:
+        cmd: stow "{{ item.path | basename }}"
+        chdir: '{{ ansible_user_dir }}/.dotfiles/'
+      with_items: '{{ find_result.files }}'
+
+- name: Create not standard XDG dirs
+  ansible.builtin.file:
+    path: '{{ ansible_user_dir }}/{{ item }}'
+    state: directory
+  with_items: '{{ my_std_xdg_path }}'
+
+- name: Download nord theme alacritty
+  ansible.builtin.get_url:
+    url: '{{ nord_alatty_url }}'
+    dest: '{{ ansible_user_dir }}/.config/alacritty/nord.yml'
+
+- name: Download and install Hack Nerd Fonts
+  block:
+    - name: Download Hack Nerd Fonts
+      ansible.builtin.get_url:
+        url: '{{ font_url }}'
+        dest: '{{ ansible_user_dir }}/.local/share/fonts/Hack/'
+    - name: Install Hack Nerd Fonts
+      ansible.builtin.command: fc-cache -f
+
+- name: Download default wallpaper
+  ansible.builtin.get_url:
+    url: '{{ wallpaper_url }}'
+    dest: '{{ ansible_user_dir }}/Pictures/Wallpapers/nord.jpg'

--- a/ansible/.ansible/dwm/roles/conf/tasks/fedora.yml
+++ b/ansible/.ansible/dwm/roles/conf/tasks/fedora.yml
@@ -1,0 +1,34 @@
+---
+# tasks/common.yml
+
+- name: Xorg conf
+  block:
+    - name: Create dir conf
+      ansible.builtin.file:
+        path: '{{ item.dest | dirname }}'
+        state: directory
+      with_items: '{{ xorg_conf }}'
+    - name: Copy conf
+      ansible.builtin.copy:
+        src: '{{ item.src }}'
+        dest: '{{ item.dest }}'
+        owner: root
+        group: root
+        mode: 0644
+      with_items: '{{ xorg_conf }}'
+
+- name: Change dwm path
+  vars:
+    my_user_home: '{{ ansible_user_dir }}'
+  ansible.builtin.replace:
+    path: '{{ xorg_conf[0].dest }}'
+    regexp: Exec=*
+    replace: Exec={{ my_user_home }}/.local/bin/dwm
+
+- name: Firewalld conf
+  ansible.builtin.command: firewall-cmd --set-default-zone=drop
+
+- name: Chsh fish
+  ansible.builtin.user:
+    name: '{{ ansible_user_id }}'
+    shell: /usr/bin/fish

--- a/ansible/.ansible/dwm/roles/conf/tasks/main.yml
+++ b/ansible/.ansible/dwm/roles/conf/tasks/main.yml
@@ -1,87 +1,22 @@
 ---
 # tasks/main.yml
 
-- name: Xorg conf
+- name: Fedora
   block:
-    - name: Create dir conf
-      ansible.builtin.file:
-        path: '{{ item.dest | dirname }}'
-        state: directory
-      with_items: '{{ xorg_conf }}'
-    - name: Copy conf
-      ansible.builtin.copy:
-        src: '{{ item.src }}'
-        dest: '{{ item.dest }}'
-        owner: root
-        group: root
-        mode: 0644
-      with_items: '{{ xorg_conf }}'
+    - ansible.builtin.include_tasks:
+        file: fedora.yml
   become: yes
+  when: ansible_distribution == "Fedora"
 
-- name: Change dwm path
-  vars:
-    my_user_home: '{{ ansible_user_dir }}'
-  ansible.builtin.replace:
-    path: '{{ xorg_conf[0].dest }}'
-    regexp: Exec=*
-    replace: Exec={{ my_user_home }}/.local/bin/dwm
-  become: yes
-
-- name: Firewalld conf
-  ansible.builtin.command: firewall-cmd --set-default-zone=drop
-  become: yes
-
-- name: GNU/Stow
+- name: Alpine Linux
   block:
-    - name: Remove default configs
-      ansible.builtin.file:
-        path: '{{ ansible_user_dir }}/{{ item }}'
-        state: absent
-      with_items: '{{ file_to_rm }}'
-    - name: Create some locations
-      ansible.builtin.file:
-        path: '{{ ansible_user_dir }}/{{ item }}'
-        state: directory
-      with_items: '{{ path_to_mk }}'
-    - name: Collect paths to stow
-      ansible.builtin.find:
-        paths: '{{ ansible_user_dir }}/.dotfiles/'
-        file_type: directory
-        excludes: .cache,.git,.github,Xorg
-      register: find_result
-    - name: Stow them
-      ansible.builtin.shell:
-        cmd: stow "{{ item.path | basename }}"
-        chdir: '{{ ansible_user_dir }}/.dotfiles/'
-      with_items: '{{ find_result.files }}'
-
-- name: Chsh fish
-  ansible.builtin.user:
-    name: '{{ ansible_user_id }}'
-    shell: /usr/bin/fish
+    - ansible.builtin.include_vars:
+        file: alpine.yml
+    - ansible.builtin.include_tasks:
+        file: alpine.yml
   become: yes
+  when: ansible_distribution == "Alpine"
 
-- name: Create (my) standard xdg paths
-  ansible.builtin.file:
-    path: '{{ ansible_user_dir }}/{{ item }}'
-    state: directory
-  with_items: '{{ my_std_xdg_path }}'
-
-- name: Download nord theme alacritty
-  ansible.builtin.get_url:
-    url: '{{ nord_alatty_url }}'
-    dest: '{{ ansible_user_dir }}/.config/alacritty/nord.yml'
-
-- name: Download and install Hack Nerd Fonts
-  block:
-    - name: Download Hack Nerd Fonts
-      ansible.builtin.get_url:
-        url: '{{ font_url }}'
-        dest: '{{ ansible_user_dir }}/.local/share/fonts/Hack/'
-    - name: Install Hack Nerd Fonts
-      ansible.builtin.command: fc-cache -f
-
-- name: Download default wallpaper
-  ansible.builtin.get_url:
-    url: '{{ wallpaper_url }}'
-    dest: '{{ ansible_user_dir }}/Pictures/Wallpapers/nord.jpg'
+- name: Common
+  ansible.builtin.include_tasks:
+    file: common.yml

--- a/ansible/.ansible/dwm/roles/conf/vars/alpine.yml
+++ b/ansible/.ansible/dwm/roles/conf/vars/alpine.yml
@@ -1,0 +1,9 @@
+---
+# vats/alpine.yml
+
+rc_services:
+  - dbus
+  - dhcpcd
+  - elogind
+  - fwupd
+  - nftables

--- a/ansible/.ansible/dwm/roles/conf/vars/main.yml
+++ b/ansible/.ansible/dwm/roles/conf/vars/main.yml
@@ -1,3 +1,4 @@
+---
 # vars/main.yml
 
 xorg_conf:

--- a/ansible/.ansible/dwm/roles/git/tasks/main.yml
+++ b/ansible/.ansible/dwm/roles/git/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # tasks/main.yml
 
 - name: Clone forked gits

--- a/ansible/.ansible/dwm/roles/git/vars/main.yml
+++ b/ansible/.ansible/dwm/roles/git/vars/main.yml
@@ -1,3 +1,4 @@
+---
 # vars/main.yml
 
 forked_gits:

--- a/ansible/.ansible/dwm/roles/pkg/tasks/alpine.yml
+++ b/ansible/.ansible/dwm/roles/pkg/tasks/alpine.yml
@@ -1,0 +1,35 @@
+---
+# tasks/alpine.yml
+
+- name: Update pkgs
+  community.general.apk:
+    upgrade: yes
+    update_cache: yes
+
+- name: Add needed pkgs
+  block:
+    - name: Apk add
+      community.general.apk:
+        name: '{{ base + base_deps + base_libs + build + utils }}'
+        state: present
+        update_cache: yes
+    - name: Setup base xorg
+      ansible.builtin.shell:
+        cmd: setup-xorg-base
+    - name: Apk add plus
+      community.general.apk:
+        name: '{{ audio_deps + input_deps + net_deps + uefi_bios_deps + video_deps + xorg_deps }}'
+        state: present
+        update_cache: yes
+    - name: Apk add edge/community
+      community.general.apk:
+        name: '{{ edge_community }}'
+        state: present
+        update_cache: yes
+        repository: '{{ edge_community_repo }}'
+    - name: Apk add edge/testing
+      community.general.apk:
+        name: '{{ edge_testing }}'
+        state: present
+        update_cache: yes
+        repository: '{{ edge_testing_repo }}'

--- a/ansible/.ansible/dwm/roles/pkg/tasks/common.yml
+++ b/ansible/.ansible/dwm/roles/pkg/tasks/common.yml
@@ -1,0 +1,18 @@
+---
+# tasks/common.yml
+
+- name: Add user needed pkgs
+  block:
+    - name: Flatpak install
+      community.general.flatpak:
+        name: '{{ item }}'
+        state: present
+        method: user
+      with_items: '{{ flathub }}'
+    - name: Pip install
+      ansible.builtin.pip:
+        name: '{{ item }}'
+        state: present
+        executable: /usr/bin/pip
+        extra_args: --user
+      with_items: '{{ pypi }}'

--- a/ansible/.ansible/dwm/roles/pkg/tasks/fedora.yml
+++ b/ansible/.ansible/dwm/roles/pkg/tasks/fedora.yml
@@ -1,0 +1,20 @@
+---
+# tasks/fedora.yml
+
+- name: Update pkgs
+  ansible.builtin.dnf:
+    name: '*'
+    state: latest
+    update_cache: yes
+
+- name: Add needed pkgs
+  block:
+    - name: Dnf install
+      ansible.builtin.dnf:
+        name: '{{ base + base_deps + base_libs + build + utils }}'
+        state: present
+        update_cache: yes
+    - name: Dnf remove
+      ansible.builtin.dnf:
+        name: firefox
+        state: absent

--- a/ansible/.ansible/dwm/roles/pkg/tasks/main.yml
+++ b/ansible/.ansible/dwm/roles/pkg/tasks/main.yml
@@ -1,28 +1,24 @@
+---
 # tasks/main.yml
 
-- name: Update pkgs
-  ansible.builtin.dnf:
-    name: '*'
-    state: latest
-    update_cache: yes
-  become: yes
-
-- name: Add needed pkgs
+- name: Fedora
   block:
-    - name: Dnf install
-      ansible.builtin.dnf:
-        name: '{{ base + base_deps + base_libs + build + utils }}'
-        state: present
-        update_cache: yes
-      become: yes
-    - name: Flatpak install
-      community.general.flatpak:
-        name: '{{ item }}'
-        state: present
-        method: user
-      with_items: '{{ flathub }}'
-    - name: Pip install
-      ansible.builtin.pip:
-        name: '{{ item }}'
-        state: present
-      with_items: '{{ pypi }}'
+    - ansible.builtin.include_vars:
+        file: fedora.yml
+    - ansible.builtin.include_tasks:
+        file: fedora.yml
+  become: yes
+  when: ansible_distribution == "Fedora"
+
+- name: Alpine Linux
+  block:
+    - ansible.builtin.include_vars:
+        file: alpine.yml
+    - ansible.builtin.include_tasks:
+        file: alpine.yml
+  become: yes
+  when: ansible_distribution == "Alpine"
+
+- name: Common
+  ansible.builtin.include_tasks:
+    file: common.yml

--- a/ansible/.ansible/dwm/roles/pkg/vars/alpine.yml
+++ b/ansible/.ansible/dwm/roles/pkg/vars/alpine.yml
@@ -1,0 +1,124 @@
+---
+# vars/alpine.yml
+
+base:
+  - alacritty
+  - bash
+  - bash-completion
+  - bash-doc
+  - bat
+  - fd
+  - fish
+  - fzf
+  - htop
+  - mandoc
+  - neovim
+  - pass
+  - ranger
+  - rofi
+
+base_deps:
+  - curl
+  - feh
+  - ffmpeg
+  - hunspell
+  - mpv
+  - picom
+  - pwgen
+  - py3-cffi
+  - py3-pexpect
+  - py3-pip
+  - py3-wheel
+  - python3-dev
+  - restic
+  - ripgrep
+  - screen
+  - sqlite
+  - stow
+  - tmux
+  - xclip
+  - xsel
+
+audio_deps:
+  - pipewire
+  - pipewire-pulse
+  - rtkit
+  - wireplumber
+
+input_deps:
+  - android-tools
+  - lm-sensors
+  - udisks2
+  - udisks2-doc
+  - usbutils
+  - wpa_supplicant
+  - xf86-input-libinput
+
+net_deps:
+  - dhcpcd
+  - nftables
+
+uefi_bios_deps:
+  - fwupd
+  - fwupd-plugin-all
+  - intel-ucode
+
+video_deps:
+  - mesa-vulkan-intel
+  - pciutils
+  - xf86-video-intel
+
+xorg_deps:
+  - dbus
+  - dbus-openrc
+  - dbus-x11
+  - elogind
+  - polkit-elogind
+  - font-noto
+  - font-noto-emoji
+  - libuser
+  - setxkbmap
+  - ttf-dejavu
+  - ttf-droid
+  - ttf-freefont
+  - ttf-liberation
+  - xdg-user-dirs
+  - xinput
+  - xrandr
+  - xset
+
+build:
+  - build-base
+  - clang
+  - gcc
+  - g++
+  - meson
+
+base_libs:
+  #- glew
+  #- libxcomposite
+  - harfbuzz-dev
+  - libx11-dev
+  - libxcb-dev
+  - libxcursor-dev
+  - libxft-dev
+  - libxinerama-dev
+  - libxrandr-dev
+  - pulseaudio-dev
+
+utils:
+  - encfs
+  - socat
+
+edge_community:
+  - delta
+
+edge_testing:
+  #- maim
+  #- slop
+  - atool
+  - cxxopts-dev
+
+edge_community_repo: https://dl-cdn.alpinelinux.org/alpine/edge/community
+
+edge_testing_repo: https://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/ansible/.ansible/dwm/roles/pkg/vars/fedora.yml
+++ b/ansible/.ansible/dwm/roles/pkg/vars/fedora.yml
@@ -1,0 +1,55 @@
+---
+# vars/fedora.yml
+
+base:
+  - alacritty
+  - bat
+  - git-delta
+  - fd-find
+  - fish
+  - fzf
+  - htop
+  - neovim
+  - pass
+  - ranger
+  - rofi
+
+base_deps:
+  - NetworkManager-tui
+  - atool
+  - brightnessctl
+  - feh
+  - ffmpeg
+  - hunspell-it
+  - lm_sensors
+  - maim
+  - mpv
+  - picom
+  - pwgen
+  - python3-wheel
+  - restic
+  - ripgrep
+  - slop
+  - stow
+  - xclip
+  - xsel
+
+build:
+  - clang
+  - gcc-c++
+  - meson
+
+base_libs:
+  - cxxopts-devel
+  - harfbuzz-devel
+  - libX11-devel
+  - libXft-devel
+  - libXinerama-devel
+  - libXrandr-devel
+  - libxcb-devel
+  - pulseaudio-libs-devel
+
+utils:
+  - fuse-encfs
+  - socat
+  - srm

--- a/ansible/.ansible/dwm/roles/pkg/vars/main.yml
+++ b/ansible/.ansible/dwm/roles/pkg/vars/main.yml
@@ -1,65 +1,12 @@
 ---
 # vars/main.yml
 
-base:
-  - alacritty
-  - bat
-  - git-delta
-  - fd-find
-  - fish
-  - fzf
-  - htop
-  - neovim
-  - pass
-  - ranger
-  - rofi
-
-base_deps:
-  - NetworkManager-tui
-  - atool
-  - brightnessctl
-  - feh
-  - ffmpeg
-  - hunspell-it
-  - lm_sensors
-  - maim
-  - mpv
-  - pandoc
-  - picom
-  - pwgen
-  - ripgrep
-  - slop
-  - stow
-  - xclip
-  - xsel
-
-build:
-  - clang
-  - gcc-c++
-  - meson
-
 flathub:
+  - org.mozilla.firefox
   - org.telegram.desktop
-
-base_libs:
-  - boost-devel
-  - harfbuzz-devel
-  - libX11-devel
-  - libXft-devel
-  - libXinerama-devel
-  - libXrandr-devel
-  - libxcb-devel
-  - pulseaudio-libs-devel
 
 pypi:
   - ipython
+  - pulsemixer
   - pynvim
   - youtube_dl
-
-utils:
-  - firejail
-  - fuse-encfs
-  - passmenu
-  - restic
-  - socat
-  - srm

--- a/ansible/.ansible/dwm/roles/repo/tasks/alpine.yml
+++ b/ansible/.ansible/dwm/roles/repo/tasks/alpine.yml
@@ -1,0 +1,26 @@
+---
+# tasks/alpine.yml
+
+- name: Patch repositories
+  block:
+    - name: Enable community repo
+      ansible.builtin.replace:
+        path: /etc/apk/repositories
+        regexp: '^#(.*(?<!edge)\/community.*)'
+        replace: '\1'
+    - name: Trim whitespaces
+      ansible.builtin.replace:
+        path: /etc/apk/repositories
+        regexp: ' '
+        replace: ''
+    - name: Https
+      ansible.builtin.replace:
+        path: /etc/apk/repositories
+        regexp: 'http:'
+        replace: 'https:'
+
+- name: Apk add flatpak
+  community.general.apk:
+    name: flatpak
+    state: present
+    update_cache: yes

--- a/ansible/.ansible/dwm/roles/repo/tasks/common.yml
+++ b/ansible/.ansible/dwm/roles/repo/tasks/common.yml
@@ -1,0 +1,9 @@
+---
+# tasks/common.yml
+
+- name: Add flathub repo
+  community.general.flatpak_remote:
+    name: flathub
+    state: present
+    flatpakrepo_url: '{{ flathub_repo }}'
+    method: user

--- a/ansible/.ansible/dwm/roles/repo/tasks/fedora.yml
+++ b/ansible/.ansible/dwm/roles/repo/tasks/fedora.yml
@@ -1,0 +1,12 @@
+---
+# tasks/fedora.yml
+
+- name: Import rpmfusion free key
+  ansible.builtin.rpm_key:
+    key: '{{ rpmfusion_free_key }}'
+    state: present
+
+- name: Add rpmfusion_free repos
+  ansible.builtin.dnf:
+    name: '{{ rpmfusion_repo }}'
+    state: present

--- a/ansible/.ansible/dwm/roles/repo/tasks/main.yml
+++ b/ansible/.ansible/dwm/roles/repo/tasks/main.yml
@@ -1,20 +1,24 @@
+---
 # tasks/main.yml
 
-- name: Import rpmfusion free key
-  ansible.builtin.rpm_key:
-    key: '{{ rpmfusion_free_key }}'
-    state: present
+- name: Fedora
+  block:
+    - ansible.builtin.include_vars:
+        file: fedora.yml
+    - ansible.builtin.include_tasks:
+        file: fedora.yml
   become: yes
+  when: ansible_distribution == "Fedora"
 
-- name: Add rpmfusion_free repos
-  ansible.builtin.dnf:
-    name: '{{ rpmfusion_repo }}'
-    state: present
+- name: Alpine Linux
+  block:
+    - ansible.builtin.include_vars:
+        file: alpine.yml
+    - ansible.builtin.include_tasks:
+        file: alpine.yml
   become: yes
+  when: ansible_distribution == "Alpine"
 
-- name: Add flathub repo
-  community.general.flatpak_remote:
-    name: flathub
-    state: present
-    flatpakrepo_url: '{{ flathub_repo }}'
-    method: user
+- name: Common
+  ansible.builtin.include_tasks:
+    file: common.yml

--- a/ansible/.ansible/dwm/roles/repo/vars/alpine.yml
+++ b/ansible/.ansible/dwm/roles/repo/vars/alpine.yml
@@ -1,0 +1,1 @@
+# vars/alpine.yml

--- a/ansible/.ansible/dwm/roles/repo/vars/fedora.yml
+++ b/ansible/.ansible/dwm/roles/repo/vars/fedora.yml
@@ -1,0 +1,5 @@
+# vars/fedora.yml
+
+rpmfusion_free_key: "https://rpmfusion.org/keys?action=AttachFile&do=get&target=RPM-GPG-KEY-rpmfusion-free-fedora-2020"
+
+rpmfusion_repo: "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_distribution_major_version }}.noarch.rpm"

--- a/ansible/.ansible/dwm/roles/repo/vars/main.yml
+++ b/ansible/.ansible/dwm/roles/repo/vars/main.yml
@@ -1,7 +1,4 @@
-# vars/maim.yml
+---
+# vars/main.yml
 
 flathub_repo: "https://dl.flathub.org/repo/flathub.flatpakrepo"
-
-rpmfusion_free_key: "https://rpmfusion.org/keys?action=AttachFile&do=get&target=RPM-GPG-KEY-rpmfusion-free-fedora-2020"
-
-rpmfusion_repo: "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ ansible_distribution_major_version }}.noarch.rpm"

--- a/ansible/.ansible/dwm/update.yml
+++ b/ansible/.ansible/dwm/update.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: thinkpad
+- hosts: laptop
   tasks:
     - name: dnf update
       ansible.builtin.dnf:
@@ -10,3 +10,16 @@
     - name: flatpak update
       ansible.builtin.shell: |
         flatpak --user update --assumeyes --noninteractive
+    - name: get outdated pip packages
+      ansible.builtin.shell:
+        cmd: |
+          pip list --user --outdated | awk '{print $1}' | tail -n +3
+          exit 0
+      register: pypi
+    - name: pip install
+      ansible.builtin.pip:
+        name: '{{ item }}'
+        state: present
+        executable: /usr/bin/pip
+        extra_args: --user --upgrade
+      with_items: '{{ pypi.stdout_lines }}'

--- a/dwmstatusbar/.local/bin/sb-volume
+++ b/dwmstatusbar/.local/bin/sb-volume
@@ -2,6 +2,10 @@
 
 # Prints the current volume or M if muted.
 
+case $BLOCK_BUTTON in
+   1) setsid -f alacritty -e pulsemixer ;;
+esac
+
 [ $(pamixer --get-mute) = true ] && echo "M" && exit
 
 vol="$(pamixer --get-volume)"

--- a/dwmstatusbar/.local/bin/sb-volume-mic
+++ b/dwmstatusbar/.local/bin/sb-volume-mic
@@ -2,6 +2,10 @@
 
 # Prints the current mic volume or M if muted.
 
+case $BLOCK_BUTTON in
+   1) setsid -f alacritty -e pulsemixer ;;
+esac
+
 [ $(pamixer --default-source --get-mute) = true ] && echo M && exit
 
 vol="$(pamixer --default-source --get-volume)"

--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -4,6 +4,9 @@
 if status is-login
    # Set XDG_CONFIG_HOME
    set -q XDG_CONFIG_HOME; or set -x XDG_CONFIG_HOME ~/.config
+   # Set XDG_DATA_DIRS
+   set -q XDG_DATA_DIRS; or set -x XDG_DATA_DIRS \
+      ~/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share/:/usr/share/
    # Change PATH
    set -x PATH "$HOME/.local/bin" $PATH
    # If FISHER not installed, install it with plugins
@@ -33,6 +36,15 @@ if status is-login
    set -x BAT_THEME 'Nord'
    # Set my FISH color theme
    set -q fish_my_color_theme; or fish_set_my_color_theme
+   # Startx for Alpine Linux (.xinitrc no gdm)
+   if test (awk -F '=' '/^ID=/ {print $2}' /etc/os-release) = 'alpine'
+      if test -z "$DISPLAY" -a "$XDG_VTNR"=1 -a (tty) = "/dev/tty1"
+         # Tweak PATH appending
+         set -ax PATH /usr/local/bin /usr/local/sbin /usr/sbin /sbin
+         # Startx
+         exec startx -- -keeptty
+      end
+   end
 else
    # Default FZF command
    ## for fzf fisher plugin

--- a/rofi-power/.config/rofi-power/config
+++ b/rofi-power/.config/rofi-power/config
@@ -1,5 +1,6 @@
 # configuration for rofi-power tool
-LAUNCHER="rofi -width 30 -lines 5 -dmenu -i"
+LAUNCHER="rofi -dmenu -i"
+STYLE="window {width: 30%;} listview {lines: 5;}"
 LOCKER="slock"
 PROMPT="rofi-power > "
 USE_LOCKER="true"

--- a/rofi-power/.local/bin/rofi-power
+++ b/rofi-power/.local/bin/rofi-power
@@ -12,7 +12,7 @@ if [ -f $HOME/.config/rofi-power/config ]; then
   source $HOME/.config/rofi-power/config
 else
   PROMPT="rofi-power"
-  LAUNCHER="rofi -width 30 -dmenu -i"
+  LAUNCHER="rofi -dmenu -i"
   USE_LOCKER="false"
   LOCKER="i3lock"
 fi
@@ -22,7 +22,13 @@ if [ ${#1} -gt 0 ]; then
   OPTIONS="Exit window manager\n$OPTIONS"
 fi
 
-option=`echo -e $OPTIONS | $LAUNCHER -p "$PROMPT" | awk '{print $2}' | tr -d '\r\n'`
+# Systemd (systemctl) or elogind (loginctl)
+type loginctl  > /dev/null 2>&1 && POWERCMD="loginctl"
+type systemctl > /dev/null 2>&1 && POWERCMD="systemctl"
+
+option=`echo -e $OPTIONS | \
+   $LAUNCHER -theme-str "$STYLE" -p "$PROMPT" \
+   | awk '{print $2}' | tr -d '\r\n'`
 if [ ${#option} -gt 0 ]
 then
     case $option in
@@ -30,16 +36,16 @@ then
         eval $1
         ;;
       Reboot)
-        systemctl reboot
+        $POWERCMD reboot
         ;;
       Power-off)
-        systemctl poweroff
+        $POWERCMD poweroff
         ;;
       Suspend)
-        $($USE_LOCKER) && "$LOCKER" & &> /dev/null; systemctl suspend;
+        $($USE_LOCKER) && "$LOCKER" & &> /dev/null; sleep 0.5; $POWERCMD suspend;
         ;;
       Hibernate)
-        $($USE_LOCKER) && "$LOCKER" & &> /dev/null; systemctl hibernate;
+        $($USE_LOCKER) && "$LOCKER" & &> /dev/null; sleep 0.5; $POWERCMD hibernate;
         ;;
       *)
         ;;

--- a/rofi/.config/rofi/config.rasi
+++ b/rofi/.config/rofi/config.rasi
@@ -1,0 +1,13 @@
+/* config.rasi */
+
+configuration {
+   modi: "window,run,ssh,drun";
+   font: "DejaVu Sans Mono 15";
+   terminal: "alacritty";
+   ssh-command: "{terminal} -e {ssh-client} {host}";
+   case-sensitive: false;
+   parse-known-hosts: false;
+   matching: "fuzzy";
+}
+
+@theme "nord"

--- a/rofi/.config/rofi/config.rasi
+++ b/rofi/.config/rofi/config.rasi
@@ -7,7 +7,6 @@ configuration {
    ssh-command: "{terminal} -e {ssh-client} {host}";
    case-sensitive: false;
    parse-known-hosts: false;
-   matching: "fuzzy";
 }
 
 @theme "nord"

--- a/rofi/.config/rofi/nord.rasi
+++ b/rofi/.config/rofi/nord.rasi
@@ -1,7 +1,5 @@
-/**
- * rofi -dump-theme output.
- * Rofi version: 1.6.1
- **/
+/* nord.rasi */
+
 * {
     red:                         rgba ( 220, 50, 47, 100 % );
     selected-active-foreground:  rgba ( 216, 222, 233, 90 % );
@@ -87,6 +85,9 @@ window {
     padding:          20;
     background-color: var(background);
     border:           0;
+    width:            50%;
+    location:         center;
+    anchor:           center;
 }
 mainbox {
     padding: 0;
@@ -107,6 +108,7 @@ listview {
     spacing:      3px ;
     fixed-height: 0;
     border:       0px ;
+    lines:        11;
 }
 scrollbar {
     width:        4px ;


### PR DESCRIPTION
With my (light/minimal) workspace,`dwm` as windows manager and other minimal/light tools running around it ... **fedora** as base distro isn't a good choice (as spirit, a lot blotware that I don't need). It works well, but let's try something completely different.
I tried to add support, inside playbooks, for my `dwm` workspace deploy starting from  _a security-oriented, lightweight Linux distribution based on musl libc and busybox_ ... **alpine linux**
Little simple comparison:
* **fedora**
   + `free --mega` 1272M
   + `df -h / /home` ~21G
* **alpine linux**
   + `free --mega` 172M
   + `df -h / /home` ~5G

Not all already tuned, but experience is very similar