### PR TITLE
build(deps): bump ansible-core from 2.15.11 to 2.15.12 in /ansible/.ansible/dwm/requirements/ansible in the ansible group

### DIFF
--- a/ansible/.ansible/dwm/requirements/ansible/ansible-dev.txt
+++ b/ansible/.ansible/dwm/requirements/ansible/ansible-dev.txt
@@ -6,7 +6,7 @@
 #
 ansible-compat==4.1.11
     # via ansible-lint
-ansible-core==2.15.11
+ansible-core==2.15.12
     # via
     #   -r ansible-dev.in
     #   ansible-compat

--- a/ansible/.ansible/dwm/requirements/ansible/ansible.txt
+++ b/ansible/.ansible/dwm/requirements/ansible/ansible.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=ansible.txt ansible.in
 #
-ansible-core==2.15.11
+ansible-core==2.15.12
     # via -r ansible.in
 cffi==1.16.0
     # via cryptography


### PR DESCRIPTION
Bumps the ansible group in /ansible/.ansible/dwm/requirements/ansible with 1 update: [ansible-core](https://github.com/ansible/ansible).


Updates `ansible-core` from 2.15.11 to 2.15.12
- [Release notes](https://github.com/ansible/ansible/releases)
- [Commits](https://github.com/ansible/ansible/compare/v2.15.11...v2.15.12)

---
updated-dependencies:
- dependency-name: ansible-core dependency-type: direct:production update-type: version-update:semver-patch dependency-group: ansible ...